### PR TITLE
reapply 6d1cd4a09 and 32a7f2ee069cc28 from LieTypes

### DIFF
--- a/LieAlgebraRepresentations/documentation.m2
+++ b/LieAlgebraRepresentations/documentation.m2
@@ -78,19 +78,90 @@ doc ///
     Outputs
         b:Boolean
     Description
-        Text
-	    This function tests equality of the underlying hash tables of $g$ and $h$ are the same.    
-	       
         Example
 	    g=simpleLieAlgebra("A",2)
 	    h=simpleLieAlgebra("A",2)
 	    g==h
+        Text
+	    When dealing with subalgebras, Lie algebras can be isomorphic but different:
+        Example
+	    g1=subLieAlgebra(g,{1}); describe g1
+	    g2=subLieAlgebra(g,{2}); describe g2
+	    g1==g2 -- false!
 ///
 
 TEST ///
     assert(simpleLieAlgebra("A",2) == simpleLieAlgebra("A",2))
 ///
 
+
+doc ///
+    Key
+        (symbol _,LieAlgebra,ZZ)
+    Headline
+        selects one summand of a semi-simple Lie Algebra
+    Usage
+        g_n
+    Inputs
+        g:LieAlgebra
+	n:ZZ
+    Outputs
+        h:LieAlgebra
+    Description
+        Example
+	    g=simpleLieAlgebra("A",2) ++ simpleLieAlgebra("A",2)
+	    g_0
+        Text
+	    Note that the same result can be obtained by using @TO subLieAlgebra@:
+	Example
+	    dynkinDiagram g
+	    g_0 == subLieAlgebra(g,{1,2})
+	    g_1 == subLieAlgebra(g,{3,4})
+///
+
+TEST ///
+    g=𝔞_1++𝔞_2
+    assert(g_0 == subLieAlgebra(g,{1}))
+    assert(isIsomorphic(g_0,𝔞_1))
+///
+
+doc ///
+    Key
+        (symbol _*,LieAlgebra)
+    Headline
+        gives the list of summands of a semi-simple Lie Algebra
+    Usage
+        g_*
+    Inputs
+        g:LieAlgebra
+    Description
+        Example
+	    g=simpleLieAlgebra("A",2) ++ simpleLieAlgebra("A",3)
+	    g_*
+///
+
+doc ///
+    Key
+        embedding
+	(embedding,LieAlgebra,LieAlgebra)
+    Headline
+        gives the embedding of Cartan subalgebras of one Lie algebra into another
+    Usage
+        embedding(g,h)
+    Inputs
+        g:LieAlgebra
+        h:LieAlgebra
+    Description
+        Example
+	    h=simpleLieAlgebra("F",4)
+	    g=subLieAlgebra(h,{0,1}); describe g
+	    embedding(g,h)
+	    embedding(subLieAlgebra(h,"principal"),h)
+///
+TEST ///
+    assert(embedding(𝔞_1,𝔞_1)==1)
+    assert(embedding(subLieAlgebra(𝔤_2,"principal"),𝔤_2)==matrix{{6},{10}}) -- 2*rho^v
+///
 
 doc ///
     Key
@@ -678,46 +749,28 @@ TEST ///
     assert(casimirScalar(V) === 8/3)
 ///
 
--*
+
 doc ///
     Key
         isIsomorphic
-	(isIsomorphic,LieAlgebraModule,LieAlgebraModule)
+	(isIsomorphic,LieAlgebra,LieAlgebra)
     Headline
-        tests whether two Lie algebra modules are isomorphic
+        tests whether two Lie algebra are isomorphic
     Usage
-        isIsomorphic(V,W)
+        isIsomorphic(g,h)
     Inputs
-        V:LieAlgebraModule
-	W:LieAlgebraModule
+        g:LieAlgebra
+	h:LieAlgebra
     Outputs
         b:Boolean
     Description
-        Text
-	    To test whether two Lie algebra modules are isomorphic, we first test whether they are modules over the same Lie algebra, and if so, then test whether they have the same decomposition into irreducible Lie algebra modules.
-        
 	Example
-	    g=simpleLieAlgebra("A",2)
-	    M=irreducibleLieAlgebraModule({2,1},g)
-	    N=irreducibleLieAlgebraModule({1,2},g)
-	    Z=irreducibleLieAlgebraModule({0,0},g)
-	    isIsomorphic(M,N)
-	    isIsomorphic(M,M)
-	    isIsomorphic(M,M**Z)
-	    isIsomorphic(M**N,N**M)
+	    g=simpleLieAlgebra("D",4)
+	    h=subLieAlgebra(g,{2,{1,0,1,1}})
+	    isIsomorphic(h,simpleLieAlgebra("G",2))
 ///
 
-TEST ///
-    g=simpleLieAlgebra("A",2);
-    M=irreducibleLieAlgebraModule({2,1},g);
-    N=irreducibleLieAlgebraModule({1,2},g);
-    Z=irreducibleLieAlgebraModule({0,0},g);
-    assert(isIsomorphic(M,N) === false)
-    assert(isIsomorphic(M,M) === true)
-    assert(isIsomorphic(M,M**Z) === true)
-    assert(isIsomorphic(M**N,N**M) ===true)
-///
-
+-*
 doc ///
     Key
         MaxWordLength
@@ -960,26 +1013,47 @@ doc ///
     	subLieAlgebra
 	(subLieAlgebra,LieAlgebra,List)
 	(subLieAlgebra,LieAlgebra,Matrix)
+	(subLieAlgebra,LieAlgebra,String)
     Headline
         Define a sub-Lie algebra of an existing one
     Usage
        subLieAlgebra(g,S)
     Inputs
         g:LieAlgebra
-	S:{List,Matrix}
+	S:{List,Matrix,String}
     Outputs
         h:LieAlgebra
     Description
         Text
-	   @TT "S"@ must be a subset of vertices of the Dynkin diagram of @TT "g"@ (as labelled by @TO dynkinDiagram@);
-	   or a matrix whose columns are the simple coroots of the subalgebra expanded in the basis of simple coroots of @TT "g"@.
+	   For the purposes of this function, a sub-Lie algebra means an embedding of a Lie algebra into another up to linear equivalence.
+	   According to Dynkin's theory, this means that it is determined by the restriction of the embedding to the Cartan subalgebra,
+	   and that is the data provided by @TT "S"@.
+	   Specifically, @TT "S"@ must be either a subset of vertices of the Dynkin diagram of @TT "g"@ (as labelled by @TO dynkinDiagram@):
 	Example
 	   g=𝔢_8; dynkinDiagram g
 	   subLieAlgebra(g,{1,2,3,4,5,8})
+	Text
+	   The vertices are labelled from 1 to the rank of g; because we frequently want to consider the lowest root, it is labelled 0:
+	Example
 	   h=𝔣_4; dynkinDiagram h
-	   subLieAlgebra(h,matrix transpose{{1,0,0,0},{0,1,0,0},{0,0,1,0},-{2,3,2,1}}) -- simple coroots 1,2,3 and opposite of highest root
+	   subLieAlgebra(h,{0,1,2,3})
+	Text
+	   Or @TT "S"@ must be a matrix whose columns are the simple coroots of the subalgebra expanded in the basis of simple coroots of @TT "g"@:
+	Example
+	   g=𝔢_6
+	   h=subLieAlgebra(g,{2,4,{0,0,1,0,1,0},{1,0,0,0,0,1}}); describe h
+	   branchingRule(adjointModule g,h)
+	Text
+	  Or @TT "S"@ is the string @TT "principal"@, which is currently the only predefined subalgebra:
+	Example
+	   g=𝔞_2; h=subLieAlgebra(g,"principal"); describe h
+	   V=LL_(2,4) g; qdim V
+	   W=branchingRule(V,h); describe W
+	   character W
+	Text
+	  In simply laced types, principal specialisation (character of principal subalgebra) and q-dimension agree.
     Caveat
-        If @TT "S"@ is a matrix, does not check if the map of root lattices leads to a valid Lie algebra embeddng.
+        If @TT "S"@ is a matrix, does not check if the map of Cartan subalgebras leads to a valid Lie algebra embedding.
 ///
 
 TEST ///
@@ -993,6 +1067,7 @@ assert ( k#"LieAlgebraRank" === (1,1,1) and k#"RootSystemType" === ("A","A","A")
 doc ///
     Key
         branchingRule
+	(branchingRule,LieAlgebraModule,String)
         (branchingRule,LieAlgebraModule,List)
         (branchingRule,LieAlgebraModule,Matrix)
         (branchingRule,LieAlgebraModule,LieAlgebra)
@@ -1002,12 +1077,12 @@ doc ///
         branchingRule(V,S)
     Inputs
         V:LieAlgebraModule
-	S:{List,Matrix,LieAlgebra}
+	S:{String,List,Matrix,LieAlgebra}
     Outputs
         V':LieAlgebraModule
     Description
         Text
-	   @TT "S"@ must be a subset of vertices of the Dynkin diagram of the Lie algebra of @TT "V"@, or a matrix, see @TO subLieAlgebra@;
+	   @TT "S"@ must be a subset of vertices of the Dynkin diagram of the Lie algebra of @TT "V"@, or a matrix, or a string, see @TO subLieAlgebra@;
 	   or a sub-Lie algebra.
 	   Returns @TT "V"@ viewed as a module over the Lie subalgebra determined by @TT "S"@.
 	Example
@@ -1021,7 +1096,7 @@ g=simpleLieAlgebra("A",2);
 M=LL_(4,2) g;
 assert(dim branchingRule(M,{1}) == dim M)
 h=subLieAlgebra(g,matrix vector {2,2})
-assert(branchingRule(LL_(1,0)(g),h) == LL_2(h))
+assert(branchingRule(LL_(1,0)(g),h) === LL_2(h))
 ///
 
 doc ///
@@ -1038,6 +1113,9 @@ doc ///
 	   h=simpleLieAlgebra("G",2);
 	   g++h
 	   directSum(g,g,h)
+	Text
+	  Note that this is external direct sum, so if $g_i$ is a sub-Lie algebra of $h_i$, $i=1,2$,
+	  then $g_1\oplus g_2$ is a sub-Lie algebra of $h_1\oplus h_2$.
 ///
 
 doc ///
@@ -1069,7 +1147,7 @@ k=g++h
 A=LL_(1,2) g
 B=LL_(2,1) h
 M=LL_(1,2,2,1) k;
-assert ( M == A @ B )
+assert ( M === A @ B )
 assert(character(M,Strategy=>"Weyl")==character(M,Strategy=>"Freudenthal"))
 ///
 

--- a/LieAlgebraRepresentations/importsandexports.m2
+++ b/LieAlgebraRepresentations/importsandexports.m2
@@ -23,7 +23,8 @@ export {
     "isSimple",
     "cartanMatrix",
     "𝔞", "𝔟", "𝔠", "𝔡", "𝔢", "𝔣", "𝔤",
-    "subLieAlgebra"
+    "subLieAlgebra",
+    "embedding"
     }
 
 -- From lieAlgebraModules.m2

--- a/LieAlgebraRepresentations/lieAlgebras.m2
+++ b/LieAlgebraRepresentations/lieAlgebras.m2
@@ -6,13 +6,6 @@
 
 
 
--- hopefully will be integrated into Core: cache into i^th argument
-cacheValue' = (i,key) -> f -> new CacheFunction from ( x -> (
-c:=(x#i).cache;
-key':=replace(i,key,x);
-if c#?key' then c#key' else c#key'=f x
-) )
-
 -- helper functions for semisimple Lie algebras
 split = (w,L) -> ( -- split weight of semisimple algebra according to simple parts
     L=prepend(0,accumulate(plus,0,L)); -- why does accumulate suck
@@ -32,7 +25,7 @@ LieAlgebra = new Type of HashTable
 LieAlgebra.GlobalAssignHook = globalAssignFunction
 LieAlgebra.GlobalReleaseHook = globalReleaseFunction
 
-cartanMatrixQQ = (type, m) -> promote(cartanMatrix(type,m),QQ)
+cartanMatrixQQ = a -> promote(cartanMatrix a,QQ)
 characterRing = method()
 characterRing (String,ZZ) := memoize( (type,m) -> (
     Q:=sum \ entries inverse cartanMatrixQQ(type,m);
@@ -50,6 +43,39 @@ characterRing (Sequence,Sequence) := memoize( (type,m) -> if #m == 0 then ZZ[Inv
 
 characterRing LieAlgebra := g -> characterRing(g#"RootSystemType",g#"LieAlgebraRank")
 
+-- helpers
+new LieAlgebra from Sequence := (T,s) -> (
+    emb:=if #s>2 then s#2 else hashTable {}; -- note that we can't include the Lie algebra itself because this would create a loop...
+    subs:=new MutableList;
+    for h in keys emb do (
+        -- find possible sub/supalgebras from existing ones
+        F:=emb#h;
+        l:=h.cache#"Subalgebras";
+        for k in l do if not emb#?k then (
+            G:=k#"Embeddings"#h;
+            -- g == k ?
+            if F==G then return k;
+            -- g < k ?
+            H:=F//G;
+            if F==G*H then emb=merge(emb,hashTable{k=>H},last);
+            -* -- k < g ? not much we can do about it. give user a warning?
+            H:=G//F;
+            if G==F*H then print("embedding detected - please define your algebras in the opposite order");
+            *-
+            );
+        );
+    g := new LieAlgebra from {
+	"RootSystemType"=>s#0,
+	"LieAlgebraRank"=>s#1,
+	"Embeddings"=>emb,
+	cache => new CacheTable from { "Subalgebras" => subs }
+	};
+    scan(keys emb, h -> ( l:=h#cache#"Subalgebras"; l#(#l)=g )); -- we also record g in the bigger algebra
+    g
+    )
+-- ...instead we define this (internally)
+supalgebras = g -> hashTable append(pairs g#"Embeddings",g=>id_(ZZ^(plus g#"LieAlgebraRank"))) -- sup-Lie algebras including itself
+
 simpleLieAlgebra = method(
     TypicalValue => LieAlgebra
     )
@@ -64,11 +90,7 @@ simpleLieAlgebra(String,ZZ) := (type,m) -> (
     	if type=="F" and m!=4 then error "The rank for type F must be 4.";
     	if type=="G" and m!=2 then error "The rank for type G must be 2.";
 	);
-    new LieAlgebra from {
-	"LieAlgebraRank"=>m,
-	"RootSystemType"=>type,
-	subLieAlgebra => hashTable { null => id_(ZZ^m) } -- any Lie algebra is a subalgebra of itself... but we can't hardcode it cause can't have a loop in an immutable HashTable... annoying
-	}
+    new LieAlgebra from (type,m)
     )
 
 fraktur := hashTable { ("A",𝔞),("B",𝔟),("C",𝔠),("D",𝔡),("E",𝔢),("F",𝔣),("G",𝔤) }
@@ -84,18 +106,20 @@ expression LieAlgebra := g -> (
     )
 net LieAlgebra := net @@ expression;
 texMath LieAlgebra := texMath @@ expression;
+toString LieAlgebra := toString @@ expression;
+toExternalString LieAlgebra := toString @@ describe;
 
 LieAlgebra ++ LieAlgebra := directSum
 directSum LieAlgebra := identity
 LieAlgebra.directSum = args -> if #args == 1 then args#0 else (
-    subList := apply(args, g -> g#subLieAlgebra);
-    subs := null;
-    scan(subList, s -> subs = if subs===null then applyKeys(s,sequence) else combine(subs,s,append,directSum,identity)); -- collisions shouldn't occur
-    new LieAlgebra from {
-    "RootSystemType" => join apply(args, g -> sequence g#"RootSystemType" ),
-    "LieAlgebraRank" => join apply(args, g -> sequence g#"LieAlgebraRank" ),
-    subLieAlgebra => applyKeys(subs,s->if all(s,h->h===null) then null else directSum apply(#args,i->if s#i===null then args#i else s#i)) -- messy; collisions shouldn't happen because identity embedding excluded
-    })
+    subs := applyKeys(supalgebras args#0,sequence);
+    scan(1..#args-1, i -> subs = combine(subs,supalgebras args#i,append,directSum,identity)); -- collisions shouldn't occur. we don't directSum yet the keys to avoid infinite loop
+    new LieAlgebra from (
+	join apply(args, g -> sequence g#"RootSystemType"),
+	join apply(args, g -> sequence g#"LieAlgebraRank"),
+	applyPairs(subs,(s,m)->if s!=args then (directSum s,m))
+	)
+    )
 
 rank LieAlgebra := g -> plus sequence g#"LieAlgebraRank"
 
@@ -120,8 +144,8 @@ dynkinDiagram (String,ZZ,ZZ) := (type,m,shift) -> if not isSimple(type,m) then e
     else if type=="B" then dynkinA (1+shift,m-1+shift,false) | ("=>=o"||pad(4,toString(m+shift)))
     else if type=="C" then dynkinA (1+shift,m-1+shift,false) | ("=<=o"||pad(4,toString(m+shift)))
     else if type=="D" then dynkinA (1+shift,m-2+shift,false) | ((" o"|toString(m-1+shift))||"/"||""||"\\"||(" o"|toString(m+shift)))^2
-    else if type=="E" then "        o 2"||"        |"|| (dynkinA (1+shift,1+shift,false)|dynkinA(3+shift,m+shift,true))
-    else if type=="F" then dynkinA (1,2,false) | ("=>=o---o"||"   3   4")
+    else if type=="E" then ("        o "|toString(2+shift))||"        |"|| (dynkinA (1+shift,1+shift,false)|dynkinA(3+shift,m+shift,true))
+    else if type=="F" then dynkinA (shift+1,shift+2,false) | ("=>=o---o"||(pad(4,toString(3+shift))|pad(4,toString(4+shift))))
     else if type=="G" then "o≡<≡o"||(toString(shift+1)|pad(4,toString(shift+2)))
     )
 dynkinDiagram (String,ZZ) := (type,m) -> dynkinDiagram(type,m,0)
@@ -134,7 +158,34 @@ dynkinDiagram LieAlgebra := g -> (
 	)
     )
 
-LieAlgebra == LieAlgebra := (V,W)-> (V===W)
+LieAlgebra == LieAlgebra := (g,h)-> g===h
+
+-- helper function: gives the type of g in a canonical form
+isomClass := g -> (
+    l:=transpose {toList sequence g#"RootSystemType",toList sequence g#"LieAlgebraRank"};
+    l=apply(l,x->if x=={"D",3} then {"A",3} else if x=={"C",2} then {"B",2} else x); -- low rank isomorphisms
+    sort l
+    )
+
+isIsomorphic(LieAlgebra,LieAlgebra) := o -> (g,h) -> isomClass g === isomClass h
+
+LieAlgebra _ ZZ := (g,n) -> (
+    type:=g#"RootSystemType";
+    m:=g#"LieAlgebraRank";
+    if class m =!= Sequence or n<0 or n>=#m then error "invalid summand";
+    r:=toList(sum(n,i->m#i)..sum(n+1,i->m#i)-1);
+    new LieAlgebra from (
+	type#n,
+	m#n,
+	applyValues(supalgebras g, e -> e_r)
+	)
+    )
+
+LieAlgebra _* := g -> (
+    m:=g#"LieAlgebraRank";
+    if class m =!= Sequence then error "invalid summand";
+    apply(#m,i->g_i)
+    )
 
 dualCoxeterNumber = method(
     TypicalValue => ZZ
@@ -208,14 +259,121 @@ scan(pairs fraktur, (let,sym) ->
 LieAlgebra#AfterPrint = g -> (
     if isSimple g then "simple ",
     class g,
-    if #(g#subLieAlgebra)>1 then (
-	lst := nonnull keys g#subLieAlgebra; -- list of supalgebras
-	mins := select(lst, h -> not any(lst, k -> k#subLieAlgebra#?h)); -- find minimal elements
+    if #(g#"Embeddings")>0 then (
+	lst := keys g#"Embeddings";
+	mins := select(lst, h -> not any(lst, k -> k#"Embeddings"#?h)); -- find minimal elements
 	", subalgebra of ",
 	toSequence between(", ",mins)
 	)
  )
 
+blocks = C -> ( -- given a Cartan (or adjacency) matrix, decompose into irreducible blocks
+    n:=numRows C;
+    L:=toList(0..n-1);
+    B:={};
+    while #L>0 do (
+	-- start a new block
+	i:=first L; L=drop(L,1);
+	b:={i}; j:=0;
+	while j<#b do (
+	    L':=select(L,k->C_(b#j,k)!=0); -- we're assuming undirected adjacency or Cartan
+	    b=b|L';
+	    scan(L',k->L=delete(k,L));
+	    j=j+1;
+	    );
+	B=append(B,b);
+	);
+    B
+)
+
+lieTypeFromCartan := C -> ( -- used internally. returns (type,m,order) where order is permutation of rows/cols
+    -- in principle one could conceive not permuting at all but it would require some rewrite (positiveRoots, etc)
+    B:=blocks C;
+    type':=(); m':=(); L:={}; -- L is permutation of rows/columns to match normal Cartan matrix
+    scan(B, b -> (
+	    c:=C^b_b;
+	    n:=numRows c;
+	    -- first pass, covers 99% of cases
+	    t:=scan("A".."G",t->if c === (try cartanMatrix(t,n)) then break t);
+	    if t === null then (
+		-- let's try harder
+		local c';
+		t=scan("A".."G",t->(
+			c'=try cartanMatrix(t,n);
+			if c'=!=null and det c == det c' and sort sum entries c == sort sum entries c' -- fun fact: characterizes uniquely
+			then break t;
+			));
+		if t === null then error ("not the Cartan matrix of a semi-simple Lie algebra");
+		-- just try every permutation, damnit
+		p:=scan(permutations n,p->if c_p^p==c' then break p);
+		if p === null then error ("not the Cartan matrix of a semi-simple Lie algebra");
+		b=b_p;
+		);
+	    type'=append(type',t); m'=append(m',n);
+	    L=L|b;
+	    ));
+    (type',m',L)
+    )
+
+new LieAlgebra from Matrix := (T,C) -> ( -- define a Lie algebra based on its Cartan matrix
+    if numColumns C == 0 then return new LieAlgebra from ((),());
+    (type,m,L):=lieTypeFromCartan C;
+    h:=directSum apply(type,m,simpleLieAlgebra); -- lazy though avoids unsequence, worrying about rings etc
+    assert(cartanMatrix h == C_L^L);
+    h
+    )
+
+subLieAlgebra = method ( TypicalValue => LieAlgebra )
+
+subLieAlgebra (LieAlgebra, List) := (g,S) -> subLieAlgebra(g,if #S==0 then map(ZZ^(rank g),0,0) else matrix transpose apply(splice S,s ->
+	if class s === ZZ and s>0 and s<=rank g then apply(rank g, j -> if j+1 == s then 1 else 0)
+	else if class s === ZZ and s==0 then entries lift(-inverse cartanMatrixQQ g*vector highestRoot g,ZZ)
+	else if instance(s,Vector) and rank class s == rank g then entries s
+	else if class s === List and #s == rank g then s
+	else error "wrong argument"))
+
+-*
+    -- identify the sub-Dynkin diagram
+    S=deepSplice S;
+    S=apply(S,i->i-1);
+    C:=(cartanMatrix g)^S_S;
+    h:=new LieAlgebra from C;
+    )
+*-
+
+subLieAlgebra (LieAlgebra,Matrix) := (g,M) -> ( -- matrix of coroots
+    if ring M =!= ZZ then try M=lift(M,ZZ) else error "matrix must be integer";
+    -- in the simply laced case it'd be simply transpose M * cartanMatrix g * M. in general have to work harder
+    if numRows M != rank g then error "wrong size of coroots";
+    G := transpose M * inverse quadraticFormMatrix g * M; -- new inverse quadratic form <coroot_i|coroot_j>
+    D := diagonalMatrix apply(numColumns M,i->2/G_(i,i)); -- inverse square norm of new simple coroots
+    C := lift(D * G,ZZ);
+    (type,m,L):=lieTypeFromCartan C;
+    M=M_L; -- permuted matrix of coroots
+    if M == id_(ZZ^(rank g)) then return g; -- better this way, no weirdness of defining a new g subalgebra of g
+    new LieAlgebra from (
+	unsequence type,
+	unsequence m,
+	applyValues(supalgebras g, A -> A*M)
+	)
+    )
+
+subLieAlgebra(LieAlgebra,String) := (g,s) -> (
+    if s =!= "principal" then error "only principal subalgebra predefined";
+    if g#"RootSystemType"==="A" and g#"LieAlgebraRank"===1 then return g; -- better this way, no weirdness of defining a new g subalgebra of g
+    M := lift(2*inverse promote(cartanMatrix g,QQ)*matrix apply(rank g,i->{1}),ZZ); -- 2 rho^v = 2 sum of fundamental coweights
+    new LieAlgebra from (
+	"A",
+	1,
+	applyValues(supalgebras g, A -> A*M)
+	)
+    )
+
+embedding = method ( TypicalValue => Matrix )
+embedding(LieAlgebra,LieAlgebra) := (g,h) -> (
+    l:=supalgebras g;
+    if l#?h then l#h else error "not a Lie subalgebra"
+    )
 
 
 


### PR DESCRIPTION
One should check that the reintroduction of `isIsomorphic` is compatible with the recent changes to the `Isomorphism` package. The logic is sound -- isomorphism and equality remain the same for `LieAlgebraModule`, which makes sense if `LieAlgebraModule` is secretly an isomophism class of representations (this might need to be stated in the documentation somewhere).